### PR TITLE
Split TokenProvider into KMS and SecretsManager implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [5.0.0] - 2022-02-22
+
+### Changed
+
+- **[Breaking change]** `TokenProvider` was replaced by more specific `KmsTokenProvider` class.
+  The functionality and interface remains the same, the imports need to be changed.
+
+### Added
+
+- New `SecretsManagerTokenProvider` that relies on AWS Secrets Manager to retrieve client ID and client secret.
+  The advantage of using AWS Secrets Manager is that it can be supplied with a secret rotation function.
+
 ## [4.1.5] - 2022-02-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -88,15 +88,55 @@ let axiosClient = axios.create({ timeout: 3000 });
 new HttpClient({ client: axiosClient });
 ```
 
-### TokenProvider
+### SecretsManagerTokenProvider
+
+It uses AWS Secrets Manager to retrieve the client ID and secret and then calls the specified token endpoint the retrieve JWT.
+
+CloudFormation to create a secret. Also allow the lambda function to access the secret by attaching `AWSSecretsManagerGetSecretValuePolicy` IAM Policy.
+
+```yaml
+Auth0Secret:
+  Type: AWS::SecretsManager::Secret
+  Properties:
+    Description: 'Auth0 Client ID/Secret'
+    GenerateSecretString:
+      SecretStringTemplate: '{"Auth0ClientID": "client_id", "Auth0ClientSecret": "client_secret"}'
+      GenerateStringKey: 'Auth0ClientSecret'
+```
+
+```typescript
+import {
+  SecretsManagerTokenProvider,
+  SecretsManagerTokenConfiguration,
+} from 'lambda-essentials-ts';
+
+const configuration: SecretsManagerTokenConfiguration = {
+  clientSecretId: 'arn:aws:secretsmanager:eu-west-1:<aws_account_id>:secret:<secret_id>',
+  audience: 'https://example.com/',
+  tokenEndpoint: 'https://example.com/oauth/token',
+};
+
+const secretsManagerClient = new aws.SecretsManager({ region: 'eu-west-1' });
+const tokenProvider = new SecretsManagerTokenProvider({
+  secretsManagerClient: secretsManagerClient,
+  tokenConfiguration: configuration,
+});
+
+// recommended way to retrieve token (utilizes caching and takes care of token expiration)
+let accessToken = await tokenProvider.getToken();
+
+// or bypass caching and get new token
+accessToken = await tokenProvider.getTokenWithoutCache();
+```
+
+### KmsTokenProvider
 
 It uses AWS KMS to decrypt the client secret and then calls the specified token endpoint the retrieve JWT.
 
 ```typescript
-import axios from 'axios';
-import { TokenProvider, TokenConfiguration } from 'lambda-essentials-ts';
+import { KmsTokenProvider, KmsTokenConfiguration } from 'lambda-essentials-ts';
 
-const configuration: TokenConfiguration = {
+const configuration: KmsTokenConfiguration = {
   clientId: 'CLIENT_ID',
   encryptedClientSecret: 'BASE64_KMS_ENCRYPTED_CLIENT_SECRET',
   audience: 'https://example.com/',
@@ -104,8 +144,7 @@ const configuration: TokenConfiguration = {
 };
 
 const kmsClient = new aws.KMS({ region: 'eu-west-1' });
-const tokenProvider = new TokenProvider({
-  httpClient: axios.create(),
+const tokenProvider = new KmsTokenProvider({
   kmsClient: kmsClient,
   tokenConfiguration: configuration,
 });

--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ const tokenProvider = new SecretsManagerTokenProvider({
 });
 
 // recommended way to retrieve token (utilizes caching and takes care of token expiration)
-let accessToken = await tokenProvider.getToken();
+const accessToken = await tokenProvider.getToken();
 
-// or bypass caching and get new token
-accessToken = await tokenProvider.getTokenWithoutCache();
+// or bypass caching and get a new fresh token
+const freshAccessToken = await tokenProvider.getTokenWithoutCache();
 ```
 
 ### KmsTokenProvider
@@ -150,10 +150,10 @@ const tokenProvider = new KmsTokenProvider({
 });
 
 // recommended way to retrieve token (utilizes caching and takes care of token expiration)
-let accessToken = await tokenProvider.getToken();
+const accessToken = await tokenProvider.getToken();
 
-// or bypass caching and get new token
-accessToken = await tokenProvider.getTokenWithoutCache();
+// or bypass caching and get a new fresh token
+const freshAccessToken = await tokenProvider.getTokenWithoutCache();
 ```
 
 ### Exceptions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-essentials-ts",
-  "version": "4.1.5",
+  "version": "5.0.0",
   "description": "A selection of the finest modules supporting authorization, API routing, error handling, logging and sending HTTP requests.",
   "main": "lib/index.js",
   "private": false,
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/Cimpress-MCP/lambda-essentials-ts#readme",
   "dependencies": {
-    "aws-sdk": "2.939.0",
+    "aws-sdk": "2.1078.0",
     "axios": "0.21.1",
     "axios-cache-adapter": "2.7.3",
     "fast-safe-stringify": "2.0.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,7 @@ import Logger, { LoggerConfiguration, SuggestedLogObject } from './logger/logger
 import OpenApiWrapper from './openApi/openApiWrapper';
 import { ApiResponse } from './openApi/apiResponseModel';
 import { ApiRequest, GetRequest, PostRequest, PutRequest } from './openApi/apiRequestModel';
-import TokenProvider, {
-  TokenConfiguration,
-  TokenProviderOptions,
-  TokenProviderHttpClient,
-} from './tokenProvider/tokenProvider';
+import { TokenProviderHttpClient } from './tokenProvider/tokenProvider';
 import KmsTokenProvider, {
   KmsTokenProviderOptions,
   KmsTokenConfiguration,
@@ -36,7 +32,6 @@ export {
   ApiResponse,
   HttpClient,
   HttpLogType,
-  TokenProvider,
   KmsTokenProvider,
   SecretsManagerTokenProvider,
   ValidationException,
@@ -60,8 +55,6 @@ export type {
   GetRequest,
   PostRequest,
   PutRequest,
-  TokenConfiguration,
-  TokenProviderOptions,
   TokenProviderHttpClient,
   KmsTokenProviderOptions,
   KmsTokenConfiguration,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,14 @@ import TokenProvider, {
   TokenProviderOptions,
   TokenProviderHttpClient,
 } from './tokenProvider/tokenProvider';
+import KmsTokenProvider, {
+  KmsTokenProviderOptions,
+  KmsTokenConfiguration,
+} from './tokenProvider/kmsTokenProvider';
+import SecretsManagerTokenProvider, {
+  SecretsManagerTokenProviderOptions,
+  SecretsManagerTokenConfiguration,
+} from './tokenProvider/secretsManagerTokenProvider';
 import { ClientException } from './exceptions/clientException';
 import { ConflictException } from './exceptions/conflictException';
 import { Exception } from './exceptions/exception';
@@ -29,6 +37,8 @@ export {
   HttpClient,
   HttpLogType,
   TokenProvider,
+  KmsTokenProvider,
+  SecretsManagerTokenProvider,
   ValidationException,
   NotFoundException,
   InvalidDataException,
@@ -53,4 +63,8 @@ export type {
   TokenConfiguration,
   TokenProviderOptions,
   TokenProviderHttpClient,
+  KmsTokenProviderOptions,
+  KmsTokenConfiguration,
+  SecretsManagerTokenProviderOptions,
+  SecretsManagerTokenConfiguration,
 };

--- a/src/tokenProvider/kmsTokenProvider.ts
+++ b/src/tokenProvider/kmsTokenProvider.ts
@@ -1,0 +1,60 @@
+import { KMS } from 'aws-sdk';
+import TokenProvider, {
+  Auth0Secret,
+  TokenConfiguration,
+  TokenProviderOptions,
+} from './tokenProvider';
+
+export default class KmsTokenProvider extends TokenProvider {
+  private kmsClient: KMS;
+
+  private kmsConfiguration: KmsTokenConfiguration;
+
+  constructor(options: KmsTokenProviderOptions) {
+    if (!options.kmsClient) {
+      throw new Error('Configuration error: missing required property "kmsClient"');
+    }
+    if (!options.tokenConfiguration?.clientId) {
+      throw new Error('Configuration error: missing required property "clientId"');
+    }
+    if (!options.tokenConfiguration?.encryptedClientSecret) {
+      throw new Error('Configuration error: missing required property "encryptedClientSecret"');
+    }
+
+    super(options);
+    this.kmsClient = options.kmsClient;
+    this.kmsConfiguration = options.tokenConfiguration;
+  }
+
+  protected async getClientSecret(): Promise<Auth0Secret | undefined> {
+    const secret = await this.kmsClient
+      .decrypt({
+        CiphertextBlob: Buffer.from(this.kmsConfiguration.encryptedClientSecret, 'base64'),
+      })
+      .promise()
+      .then((data) => data.Plaintext?.toString());
+    return { Auth0ClientSecret: secret!, Auth0ClientID: this.kmsConfiguration.clientId };
+  }
+}
+
+export interface KmsTokenProviderOptions extends TokenProviderOptions {
+  /**
+   * AWS KMS Client
+   */
+  kmsClient: KMS;
+  /**
+   * Configuration needed for the token
+   */
+  tokenConfiguration: KmsTokenConfiguration;
+}
+
+export interface KmsTokenConfiguration extends TokenConfiguration {
+  /**
+   * Username or ClientId
+   */
+  clientId: string;
+  /**
+   * KMS Encrypted client secret
+   */
+  encryptedClientSecret: string;
+}

--- a/src/tokenProvider/secretsManagerTokenProvider.ts
+++ b/src/tokenProvider/secretsManagerTokenProvider.ts
@@ -1,0 +1,56 @@
+import { SecretsManager } from 'aws-sdk';
+import TokenProvider, {
+  Auth0Secret,
+  TokenConfiguration,
+  TokenProviderOptions,
+} from './tokenProvider';
+
+export default class SecretsManagerTokenProvider extends TokenProvider {
+  private secretsManagerClient: SecretsManager;
+
+  private secretsManagerConfiguration: SecretsManagerTokenConfiguration;
+
+  constructor(options: SecretsManagerTokenProviderOptions) {
+    if (!options.secretsManagerClient) {
+      throw new Error('Configuration error: missing required property "secretsManagerClient"');
+    }
+    if (!options.tokenConfiguration?.clientSecretId) {
+      throw new Error('Configuration error: missing required property "clientSecretId"');
+    }
+
+    super(options);
+    this.secretsManagerClient = options.secretsManagerClient;
+    this.secretsManagerConfiguration = options.tokenConfiguration;
+  }
+
+  protected async getClientSecret(): Promise<Auth0Secret | undefined> {
+    const secret = await this.secretsManagerClient
+      .getSecretValue({ SecretId: this.secretsManagerConfiguration.clientSecretId })
+      .promise();
+
+    return JSON.parse(secret.SecretString!) as Auth0Secret;
+  }
+}
+
+export interface SecretsManagerTokenProviderOptions extends TokenProviderOptions {
+  /**
+   * AWS Secrets Manager Client
+   */
+  secretsManagerClient: SecretsManager;
+  /**
+   * Configuration needed for the token
+   */
+  tokenConfiguration: SecretsManagerTokenConfiguration;
+}
+
+export interface SecretsManagerTokenConfiguration extends TokenConfiguration {
+  /**
+   * The ID of a secret stored in AWS Secrets Manager.
+   * The expected secret format is:
+   * {
+   *   Auth0ClientID: "string",
+   *   Auth0ClientSecret: "string"
+   * }
+   */
+  clientSecretId: string;
+}

--- a/src/tokenProvider/secretsManagerTokenProvider.ts
+++ b/src/tokenProvider/secretsManagerTokenProvider.ts
@@ -11,24 +11,21 @@ export default class SecretsManagerTokenProvider extends TokenProvider {
   private secretsManagerConfiguration: SecretsManagerTokenConfiguration;
 
   constructor(options: SecretsManagerTokenProviderOptions) {
-    if (!options.secretsManagerClient) {
-      throw new Error('Configuration error: missing required property "secretsManagerClient"');
-    }
-    if (!options.tokenConfiguration?.clientSecretId) {
-      throw new Error('Configuration error: missing required property "clientSecretId"');
-    }
-
     super(options);
     this.secretsManagerClient = options.secretsManagerClient;
     this.secretsManagerConfiguration = options.tokenConfiguration;
   }
 
-  protected async getClientSecret(): Promise<Auth0Secret | undefined> {
+  public async getClientSecret(): Promise<Auth0Secret | undefined> {
     const secret = await this.secretsManagerClient
       .getSecretValue({ SecretId: this.secretsManagerConfiguration.clientSecretId })
       .promise();
 
-    return JSON.parse(secret.SecretString!) as Auth0Secret;
+    if (!secret?.SecretString) {
+      throw new Error('Request error: failed to retrieve secret from Secrets Manager');
+    }
+
+    return JSON.parse(secret.SecretString) as Auth0Secret;
   }
 }
 

--- a/src/tokenProvider/tokenProvider.ts
+++ b/src/tokenProvider/tokenProvider.ts
@@ -11,17 +11,8 @@ export default abstract class TokenProvider {
   /**
    * Create a new Instance of the TokenProvider
    */
-  // eslint-disable-next-line complexity
-  constructor(options: TokenProviderOptions) {
+  protected constructor(options: TokenProviderOptions) {
     this.httpClient = options.httpClient ?? axios.create();
-
-    if (!options.tokenConfiguration?.audience) {
-      throw new Error('Configuration error: missing required property "audience"');
-    }
-    if (!options.tokenConfiguration?.tokenEndpoint) {
-      throw new Error('Configuration error: missing required property "tokenEndpoint"');
-    }
-
     this.configuration = options.tokenConfiguration;
   }
 
@@ -70,7 +61,7 @@ export default abstract class TokenProvider {
     return response.data.access_token;
   }
 
-  protected abstract async getClientSecret(): Promise<Auth0Secret | undefined>;
+  public abstract async getClientSecret(): Promise<Auth0Secret | undefined>;
 }
 
 export interface Auth0Secret {

--- a/tests/tokenProvider/kmsTokenProvider.test.ts
+++ b/tests/tokenProvider/kmsTokenProvider.test.ts
@@ -1,0 +1,59 @@
+import { KMS } from 'aws-sdk';
+import { KmsTokenConfiguration, KmsTokenProvider } from '../../src';
+import { Auth0Secret } from '../../src/tokenProvider/tokenProvider';
+
+describe('KMS Token Provider', () => {
+  const tokenConfiguration: KmsTokenConfiguration = {
+    clientId: 'test-client-id',
+    encryptedClientSecret: 'base64-encrypted-test-secret',
+    audience: 'https://example.com/',
+    tokenEndpoint: 'https://example.com/oauth/token',
+  };
+
+  describe('getClientSecret', () => {
+    test('throws when secret was not decrypted', async () => {
+      const promisedDecryptedText = Promise.resolve({ data: { Plaintext: undefined } });
+      const KMSMock = jest.fn().mockImplementation(
+        (): Partial<KMS> => ({
+          decrypt: jest.fn().mockReturnValue({ promise: () => promisedDecryptedText }),
+        }),
+      );
+
+      const tokenProvider = new KmsTokenProvider({
+        kmsClient: new KMSMock(),
+        tokenConfiguration,
+      });
+
+      await expect(tokenProvider.getClientSecret()).rejects.toThrowError(
+        'Request error: failed to decrypt secret using KMS',
+      );
+    });
+
+    test('returns parsed secret', async () => {
+      const expectedSecret: Auth0Secret = {
+        Auth0ClientID: 'test-client-id',
+        Auth0ClientSecret: 'test-secret',
+      };
+      const promisedDecryptedText = Promise.resolve({
+        Plaintext: expectedSecret.Auth0ClientSecret,
+      });
+      const KMSMock = jest.fn().mockImplementation(
+        (): Partial<KMS> => ({
+          decrypt: jest.fn().mockReturnValue({ promise: () => promisedDecryptedText }),
+        }),
+      );
+
+      const kms = new KMSMock();
+      const tokenProvider = new KmsTokenProvider({
+        kmsClient: kms,
+        tokenConfiguration,
+      });
+
+      const actualSecret = await tokenProvider.getClientSecret();
+      expect(actualSecret).toEqual(expectedSecret);
+      expect(kms.decrypt).toHaveBeenCalledWith({
+        CiphertextBlob: Buffer.from(tokenConfiguration.encryptedClientSecret, 'base64'),
+      });
+    });
+  });
+});

--- a/tests/tokenProvider/secretsManagerTokenProvider.test.ts
+++ b/tests/tokenProvider/secretsManagerTokenProvider.test.ts
@@ -1,0 +1,56 @@
+import { SecretsManager } from 'aws-sdk';
+import { SecretsManagerTokenConfiguration, SecretsManagerTokenProvider } from '../../src';
+import { Auth0Secret } from '../../src/tokenProvider/tokenProvider';
+
+describe('Secrets Manager Token Provider', () => {
+  const tokenConfiguration: SecretsManagerTokenConfiguration = {
+    clientSecretId: 'arn:aws:secretsmanager:eu-west-1:aws_account_id:secret:secret_id',
+    audience: 'https://example.com/',
+    tokenEndpoint: 'https://example.com/oauth/token',
+  };
+
+  describe('getClientSecret', () => {
+    test('throws when secret was not retrieved', async () => {
+      const promisedSecret = Promise.resolve({ SecretString: undefined });
+      const SecretsManagerMock = jest.fn().mockImplementation(
+        (): Partial<SecretsManager> => ({
+          getSecretValue: jest.fn().mockReturnValue({ promise: () => promisedSecret }),
+        }),
+      );
+
+      const tokenProvider = new SecretsManagerTokenProvider({
+        secretsManagerClient: new SecretsManagerMock(),
+        tokenConfiguration,
+      });
+
+      await expect(tokenProvider.getClientSecret()).rejects.toThrowError(
+        'Request error: failed to retrieve secret from Secrets Manager',
+      );
+    });
+
+    test('returns parsed secret', async () => {
+      const expectedSecret: Auth0Secret = {
+        Auth0ClientID: 'test-client-id',
+        Auth0ClientSecret: 'test-secret',
+      };
+      const promisedSecret = Promise.resolve({ SecretString: JSON.stringify(expectedSecret) });
+      const SecretsManagerMock = jest.fn().mockImplementation(
+        (): Partial<SecretsManager> => ({
+          getSecretValue: jest.fn().mockReturnValue({ promise: () => promisedSecret }),
+        }),
+      );
+
+      const secretsManager = new SecretsManagerMock();
+      const tokenProvider = new SecretsManagerTokenProvider({
+        secretsManagerClient: secretsManager,
+        tokenConfiguration,
+      });
+
+      const actualSecret = await tokenProvider.getClientSecret();
+      expect(actualSecret).toEqual(expectedSecret);
+      expect(secretsManager.getSecretValue).toHaveBeenCalledWith({
+        SecretId: tokenConfiguration.clientSecretId,
+      });
+    });
+  });
+});

--- a/tests/tokenProvider/tokenProvider.test.ts
+++ b/tests/tokenProvider/tokenProvider.test.ts
@@ -1,0 +1,72 @@
+import {
+  TokenConfiguration,
+  TokenProvider,
+  TokenProviderHttpClient,
+  TokenProviderOptions,
+} from '../../src';
+import { Auth0Secret } from '../../src/tokenProvider/tokenProvider';
+
+class TestTokenProvider extends TokenProvider {
+  private readonly getClientSecretResponse?: Auth0Secret;
+
+  constructor(options: TokenProviderOptions, getClientSecretResponse?: Auth0Secret) {
+    super(options);
+    this.getClientSecretResponse = getClientSecretResponse;
+  }
+
+  public async getClientSecret(): Promise<Auth0Secret | undefined> {
+    return Promise.resolve(this.getClientSecretResponse);
+  }
+}
+
+describe('Token Provider', () => {
+  const tokenConfiguration: TokenConfiguration = {
+    audience: 'https://example.com/',
+    tokenEndpoint: 'https://example.com/oauth/token',
+  };
+
+  describe('getTokenWithoutCache', () => {
+    test('throws when secret was not retrieved with all required properties', async () => {
+      const tokenProvider = new TestTokenProvider(
+        { tokenConfiguration },
+        {
+          Auth0ClientID: 'test-client-id',
+          Auth0ClientSecret: '',
+        },
+      );
+      await expect(tokenProvider.getTokenWithoutCache()).rejects.toThrowError(
+        'Request error: failed to retrieve Auth0 Client ID/Secret',
+      );
+    });
+
+    test('returns access token retrieved from tokenEndpoint', async () => {
+      const auth0Secret: Auth0Secret = {
+        Auth0ClientID: 'test-client-id',
+        Auth0ClientSecret: 'test-client-secret',
+      };
+      const tokenResponse = {
+        access_token: 'test-access-token',
+      };
+      const HttpClientMock = jest.fn().mockImplementation(
+        (): TokenProviderHttpClient => ({
+          post: jest.fn().mockResolvedValue({ data: tokenResponse }),
+        }),
+      );
+      const httpClient = new HttpClientMock();
+
+      const tokenProvider = new TestTokenProvider({ tokenConfiguration, httpClient }, auth0Secret);
+      const actualToken = await tokenProvider.getTokenWithoutCache();
+      expect(actualToken).toEqual(tokenResponse.access_token);
+      expect(httpClient.post).toHaveBeenCalledWith(
+        tokenConfiguration.tokenEndpoint,
+        {
+          client_id: auth0Secret.Auth0ClientID,
+          client_secret: auth0Secret.Auth0ClientSecret,
+          audience: tokenConfiguration.audience,
+          grant_type: 'client_credentials',
+        },
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,15 +955,15 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-sdk@2.939.0:
-  version "2.939.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.939.0.tgz#c07c9d726bcb2ffdb69016f880ae310ad72f36a5"
-  integrity sha512-2KEAtTlVMDcpHP6+P9JU+mXTNhX3KZ0StW0Qi87oh8EUoRITZj64FrUylNvrCg69thCliAcNzBdlA1g5Iq+qEA==
+aws-sdk@2.1078.0:
+  version "2.1078.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1078.0.tgz#5871750b38045f05e141e5217521f8ff8bf73a26"
+  integrity sha512-eJuiiCE4tomYzsxqfsjERmQ1WQkNAe5RUhOXUwJbGTEfwmbiQqq/HgVYrwcMswOHoURbtKpB5SSrTLNOBuyurA==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
     ieee754 "1.1.13"
-    jmespath "0.15.0"
+    jmespath "0.16.0"
     querystring "0.2.0"
     sax "1.2.1"
     url "0.10.3"
@@ -3142,10 +3142,10 @@ jest@26.2.2:
     import-local "^3.0.2"
     jest-cli "^26.2.2"
 
-jmespath@0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
-  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
+jmespath@0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
+  integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
TODO:
- [x] Split and add more unit tests

E2E:
- [x] I've tested using both KMS and SecretsManager token provider