### PR TITLE
change openapifactory version to 5.2.38

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 lib
 docs
 .dccache
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [5.1.1] - 2022-09-05
+
+### Changed
+
+HttpApi payload version 2.0 events supported for openApiWrapper.
+
 ## [5.1.0] - 2022-09-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "is-error": "~2.2.2",
     "jsonwebtoken": "~8.5.1",
     "md5": "~2.3.0",
-    "openapi-factory": "5.2.17",
+    "openapi-factory": "5.2.38",
     "retry-axios": "~2.6.0",
     "uuid": "~8.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-essentials-ts",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "A selection of the finest modules supporting authorization, API routing, error handling, logging and sending HTTP requests.",
   "main": "lib/index.js",
   "private": false,

--- a/src/openApi/openApiWrapper.ts
+++ b/src/openApi/openApiWrapper.ts
@@ -25,6 +25,7 @@ export default class OpenApiWrapper {
   private correlationId: string = this.notSet;
 
   constructor(requestLogger) {
+    // @ts-ignore Later Use the options Type from OpenApiFactory
     this.api = new OpenApi(
       {
         requestMiddleware: (request: ApiRequest): ApiRequest => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3958,10 +3958,10 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-openapi-factory@5.2.17:
-  version "5.2.17"
-  resolved "https://registry.yarnpkg.com/openapi-factory/-/openapi-factory-5.2.17.tgz#7c15b579afc77fb48d62e787a0106c26d4df54a5"
-  integrity sha512-wFwSrTSfMkrCss+yA7+wDxECFgjjuDdjoTKJAjVUYOL2ShNN4Qw6fb6VqB/u4g+1YUGBsEJlFdbQCKo+2j/WHA==
+openapi-factory@5.2.38:
+  version "5.2.38"
+  resolved "https://registry.yarnpkg.com/openapi-factory/-/openapi-factory-5.2.38.tgz#482fbcde1c4961104dcb1ecd98bb351c21fc5b92"
+  integrity sha512-hbDOGUuZ587ccm8a4XHFBEtIroVmdIFHe7ArloiyRMXU7Kr7ZPb0BhgW+H+Qx8ksKtkYAASlDvsmvNrK/o5XuQ==
 
 opencollective-postinstall@^2.0.2:
   version "2.0.3"


### PR DESCRIPTION
This version of openApiFactory adds support for HttpApi payload version 2.0.