### PR TITLE
Add missing definitions to ApiRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [5.1.2] - 2022-09-14
+
+### Changed
+
+Properties `stageVariables`, `isBase64Encoded` and `route` from openapi-factory are available in the Typescript definitions.
+
 ## [5.1.1] - 2022-09-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-essentials-ts",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "A selection of the finest modules supporting authorization, API routing, error handling, logging and sending HTTP requests.",
   "main": "lib/index.js",
   "private": false,

--- a/src/openApi/apiRequestModel.ts
+++ b/src/openApi/apiRequestModel.ts
@@ -2,6 +2,8 @@ export interface ApiRequest<Body = any, Query = any> {
   body?: Body;
   path: string;
   httpMethod: string;
+  route: string;
+  isBase64Encoded: Boolean;
   requestContext: {
     authorizer?: {
       jwt: string;
@@ -12,6 +14,7 @@ export interface ApiRequest<Body = any, Query = any> {
   };
   headers: Record<string, string>;
   pathParameters: Record<string, string>;
+  stageVariables: Record<string, string>;
   queryStringParameters?: Query;
   multiValueQueryStringParameters?: any;
 }

--- a/tests/openApi/openApi.test.ts
+++ b/tests/openApi/openApi.test.ts
@@ -25,6 +25,11 @@ describe('Open API Wrapper', () => {
       },
       requestId: 'tests-request-id',
     },
+    stageVariables: {
+      unit: 'test',
+    },
+    isBase64Encoded: false,
+    route: path,
   };
   const requestWithCorrelationHeader: ApiRequest<any> = {
     ...request,


### PR DESCRIPTION
Missing definitions taken from https://github.com/Rhosys/openapi-factory.js/blob/release/5.2/index.js