### PR TITLE
Relative URLs fail; include the baseURL if that's set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [5.1.4] - 2022-11-08
+
+### Changed
+
+Using `baseURL` in the axios config without specifying the full URL resulted in an error in the exception handling. So the `AxiosError` was thrown instead of a customer `ClientException`.
+
 ## [5.1.3] - 2022-10-03
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-essentials-ts",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "A selection of the finest modules supporting authorization, API routing, error handling, logging and sending HTTP requests.",
   "main": "lib/index.js",
   "private": false,

--- a/src/httpClient/httpClient.ts
+++ b/src/httpClient/httpClient.ts
@@ -121,7 +121,9 @@ export default class HttpClient {
           error: serializedAxiosError,
         });
 
-        const hostname = error.config?.url ? new URL(error.config.url).hostname : 'N/A';
+        const hostname = error.config?.url
+          ? new URL(error.config.url, error.config.baseURL).hostname
+          : 'N/A';
         throw new ClientException(
           hostname,
           serializedAxiosError?.status,


### PR DESCRIPTION
```javascript
// this throws an exception
new URL('/foobar');

// this works
new URL('/foobar', 'https://cool-url.com');

// this also works
new URL('/foobar', undefined);
```