### PR TITLE
fix: Include baseURL while getting hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [5.1.5] - 2022-11-15
+
+### Changed
+
+The fix described in 5.1.4 missed one instance where the bug can occur. This change covers all known instances.
+
 ## [5.1.4] - 2022-11-08
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-essentials-ts",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "A selection of the finest modules supporting authorization, API routing, error handling, logging and sending HTTP requests.",
   "main": "lib/index.js",
   "private": false,

--- a/src/httpClient/httpClient.ts
+++ b/src/httpClient/httpClient.ts
@@ -169,7 +169,9 @@ export default class HttpClient {
           });
         }
 
-        const hostname = error.config?.url ? new URL(error.config.url).hostname : 'N/A';
+        const hostname = error.config?.url
+          ? new URL(error.config.url, error.config.baseURL).hostname
+          : 'N/A';
         throw new ClientException(
           hostname,
           serializedAxiosError?.status,


### PR DESCRIPTION
This covers missed cases for the bug fixed in #40.