### PR TITLE
Mm/prc 0 log non axios errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
-HttpClient now also logs unexpected (e.g. network) rrors that are not coming from Axios
+HttpClient now also logs unexpected (e.g. network) errors that are not coming from Axios
 
 ## [5.2.0] - 2023-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [5.2.2] - 2023-08-25
+
+### Added
+
+HttpClient now also logs unexpected (e.g. network) rrors that are not coming from Axios
+
 ## [5.2.0] - 2023-06-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-essentials-ts",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "A selection of the finest modules supporting authorization, API routing, error handling, logging and sending HTTP requests.",
   "main": "lib/index.js",
   "private": false,

--- a/src/util.ts
+++ b/src/util.ts
@@ -41,7 +41,10 @@ export function serializeObject(obj: unknown, redact?: boolean): object {
 
 export function serializeAxiosError(error: AxiosError): SerializedAxiosError | undefined {
   if (!error.response) {
-    return undefined;
+    return {
+      status: 500,
+      details: error,
+    };
   }
 
   const { status, data } = error.response;

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -97,12 +97,22 @@ describe('Util', () => {
       name: 'test-name',
       toJSON: () => ({}),
     };
+
     test('serializes AxiosError objects', () => {
       const expected = {
         details: 'test-details',
         status: 409,
       };
       const serializedError = serializeAxiosError(axiosError);
+      expect(serializedError).toEqual(expected);
+    });
+
+    test('serializes any objects', () => {
+      const expected = {
+        details: error,
+        status: 500,
+      };
+      const serializedError = serializeAxiosError(error as any);
       expect(serializedError).toEqual(expected);
     });
   });


### PR DESCRIPTION
Currently we drop some errors in the logs, if they don't follow the expected Axios format. This should somewhat help